### PR TITLE
Fix IPN callback validation

### DIFF
--- a/includes/class-wc-mercadopago-gateway.php
+++ b/includes/class-wc-mercadopago-gateway.php
@@ -524,7 +524,7 @@ class WC_MercadoPago_Gateway extends WC_Payment_Gateway {
 			header( 'HTTP/1.1 200 OK' );
 			do_action( 'valid_mercadopago_ipn_request', $data );
 		} else {
-			wp_die( __( 'MercadoPago Request Failure', 'woocommerce-mercadopago' ) );
+			wp_die( __( 'MercadoPago Request Failure', 'woocommerce-mercadopago' ), 200 );
 		}
 	}
 


### PR DESCRIPTION
For some (undocumented) reason, MercadoPago has changed the request they make when validating an IPN callback.

It's not a GET request anymore like the documentation states, but a POST request with the fields "topic" and "resource" sent via encoded json. Full transaction details: 
![captura de pantalla 111](https://cloud.githubusercontent.com/assets/69187/16567529/15820160-41f6-11e6-967f-e2e21f5d5eb6.png)

This PR has a few changes that make the plugin able to handle this request.

===

I was able to verify the callback URL and make a purchase with sandbox enabled. Everything worked fine until the plugin tried to validate the transaction. I'm not sure if this is because Sandbox mode was enabled, or MercadoPago changed something else.

This is the data MP sent:
```
Array
(
    [data] => Array
        (
            [id] => 1045365
        )

    [date_created] => 2016-07-04T13:11:07.000-04:00
    [type] => payment
    [api_version] => v1
    [id] => 115875714
    [action] => payment.created
    [user_id] => **700***
    [live_mode] => 
) 
```

And this is the response the plugin got from `https://api.mercadolibre.com/sandbox/collections/notifications/115875714`:

```
{
  "message": "not_found"
}
```

I couldn't test a real transaction yet, so I can't comment on that.